### PR TITLE
Fixed usages of deprecated numpy and pandas APIs

### DIFF
--- a/pgmpy/factors/discrete/DiscreteFactor.py
+++ b/pgmpy/factors/discrete/DiscreteFactor.py
@@ -260,7 +260,7 @@ class DiscreteFactor(BaseFactor, StateNameMixin):
         if not all(i <= max_possible_index for i in index):
             raise IndexError("Index greater than max possible index")
 
-        assignments = np.zeros((len(index), len(self.scope())), dtype=np.int)
+        assignments = np.zeros((len(index), len(self.scope())), dtype=np.int32)
         rev_card = self.cardinality[::-1]
         for i, card in enumerate(rev_card):
             assignments[:, i] = index % card

--- a/pgmpy/models/BayesianModel.py
+++ b/pgmpy/models/BayesianModel.py
@@ -620,7 +620,7 @@ class BayesianModel(DAG):
 
             df_results = pd.DataFrame(pred_values, index=data_unique.index)
             data_with_results = pd.concat([data_unique, df_results], axis=1)
-            return data.merge(data_with_results, how="left").loc[:, missing_variables]
+            return data.merge(data_with_results, how="left").loc[:, list(missing_variables)]
 
     def predict_probability(self, data):
         """


### PR DESCRIPTION
- np.int has been removed in numpy 1.24, has to be replaced with np.int32
- using set as indexer has been deprecated in pandas 1.0.0, has to be type casted to a list